### PR TITLE
アプリ名をoobunからcoconikkiに変更

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,7 +2,7 @@ doctype html
 html
   head
     title
-      = content_for(:title) || "oobun"
+      = content_for(:title) || "coconikki"
     meta name="viewport" content="width=device-width,initial-scale=1"
     = csrf_meta_tags
     = csp_meta_tag
@@ -18,7 +18,7 @@ html
     header.bg-white
       nav.h-14.flex.items-center
         .px-4.flex.items-center.gap-3
-          = link_to "oobun", root_path, class: "text-lg font-semibold tracking-tight"
+          = link_to "coconikki", root_path, class: "text-lg font-semibold tracking-tight"
           = yield :back_link
 
     / ユーザーアイコン（左下固定）

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -1,8 +1,8 @@
-- content_for :title, "ログイン - oobun"
+- content_for :title, "ログイン - coconikki"
 
 .flex.flex-col.items-center.justify-center.min-h-64.gap-8
   .text-center
-    h1.text-2xl.font-semibold.mb-2 oobun にログイン
+    h1.text-2xl.font-semibold.mb-2 coconikki にログイン
     p.text-gray-500.text-sm Google アカウントでログインしてください
 
   .flex.flex-col.items-center.gap-4

--- a/app/views/threads/index.html.slim
+++ b/app/views/threads/index.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "oobun - 文通を読む"
+- content_for :title, "coconikki - 文通を読む"
 
 .flex.flex-col.gap-6
   .flex.items-center.justify-between

--- a/app/views/threads/invitations/show.html.slim
+++ b/app/views/threads/invitations/show.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "招待 - #{@invitation.thread.title} - oobun"
+- content_for :title, "招待 - #{@invitation.thread.title} - coconikki"
 
 .flex.flex-col.items-center.justify-center.min-h-64.gap-8
   .text-center.max-w-sm

--- a/app/views/threads/new.html.slim
+++ b/app/views/threads/new.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "新しいスレッド - oobun"
+- content_for :title, "新しいスレッド - coconikki"
 
 .max-w-lg.mx-auto
   h1.text-xl.font-semibold.mb-6 新しいスレッドを作成
@@ -14,7 +14,7 @@
       .flex.flex-col.gap-1
         = f.label :slug, "URL スラッグ", class: "text-sm font-medium text-gray-700"
         .flex.items-center.gap-1
-          span.text-gray-400.text-sm oobun.example.com/
+          span.text-gray-400.text-sm coconikki.example.com/
           = f.text_field :slug, placeholder: "my-thread",
               class: "flex-1 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
         p.text-xs.text-gray-400 英小文字・数字・ハイフン、3〜50文字

--- a/app/views/threads/posts/new.html.slim
+++ b/app/views/threads/posts/new.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "投稿 - #{@thread.title} - oobun"
+- content_for :title, "投稿 - #{@thread.title} - coconikki"
 
 .max-w-2xl.mx-auto
   .mb-6

--- a/app/views/threads/posts/show.html.slim
+++ b/app/views/threads/posts/show.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "#{@post.title} - #{@thread.title} - oobun"
+- content_for :title, "#{@post.title} - #{@thread.title} - coconikki"
 - content_for :back_link do
   = link_to "←", thread_path(@thread.slug), class: "text-sm text-gray-500 hover:text-gray-700", title: @thread.title
 

--- a/app/views/threads/show.html.slim
+++ b/app/views/threads/show.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "#{@thread.title} - oobun"
+- content_for :title, "#{@thread.title} - coconikki"
 
 - turn_user = @thread.current_turn_user
 - is_member = logged_in? && @thread.memberships.exists?(user: current_user)

--- a/app/views/usernames/new.html.slim
+++ b/app/views/usernames/new.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "ユーザー名の設定 - oobun"
+- content_for :title, "ユーザー名の設定 - coconikki"
 
 .flex.flex-col.items-center.justify-center.min-h-64
   .w-full.max-w-sm

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,4 +1,4 @@
-- content_for :title, "@#{@user.username} - oobun"
+- content_for :title, "@#{@user.username} - coconikki"
 
 .max-w-4xl.mx-auto
   / ユーザー情報


### PR DESCRIPTION
## 概要
ユーザーから見える部分のアプリ名を「oobun」から「coconikki」に統一しました。

## 変更内容

### ユーザー向け表示の変更
- ✅ すべてのページタイトル（`<title>`タグ）を「coconikki」に統一
- ✅ ヘッダーのロゴ表示を「coconikki」に変更
- ✅ ログイン画面の見出しを「coconikki にログイン」に変更
- ✅ URLプレビュー表示を `coconikki.example.com` に変更

### 変更されたファイル（10ファイル）
- `app/views/layouts/application.html.slim` - デフォルトタイトル、ヘッダーロゴ
- `app/views/threads/index.html.slim` - トップページタイトル
- `app/views/threads/show.html.slim` - スレッド詳細タイトル
- `app/views/threads/new.html.slim` - 新規作成ページタイトル、URLプレビュー
- `app/views/threads/posts/show.html.slim` - 投稿詳細タイトル
- `app/views/threads/posts/new.html.slim` - 投稿作成タイトル
- `app/views/threads/invitations/show.html.slim` - 招待ページタイトル
- `app/views/sessions/new.html.slim` - ログインページタイトル、見出し
- `app/views/usernames/new.html.slim` - ユーザー名設定タイトル
- `app/views/users/show.html.slim` - ユーザーページタイトル

## 開発コードネームとしての「oobun」は保持
以下はそのまま「oobun」を維持：
- ✅ GitHubリポジトリ名（`sugiwe/oobun`）
- ✅ ディレクトリ構造（`/Users/*/projects/oobun`）
- ✅ コード内部の参照・モジュール名
- ✅ データベース名
- ✅ 環境変数名

## テストプラン
- [ ] トップページのタイトルが「coconikki - 文通を読む」になっている
- [ ] ヘッダーのロゴが「coconikki」と表示される
- [ ] ログインページが「coconikki にログイン」と表示される
- [ ] 新規スレッド作成画面のURLプレビューが「coconikki.example.com/」になっている
- [ ] 各ページのブラウザタブタイトルに「coconikki」が含まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)