### PR TITLE
hotfix: ダイジェストメール送信時のActiveJob::SerializationErrorを修正

### DIFF
--- a/app/jobs/daily_digest_job.rb
+++ b/app/jobs/daily_digest_job.rb
@@ -47,7 +47,8 @@ class DailyDigestJob < ApplicationJob
       setting&.update!(last_digest_sent_at: Time.current)
 
       # ダイジェストメール送信（非同期）
-      UserMailer.daily_digest(user, notifications).deliver_later
+      # ActiveJobはRelationをシリアライズできないため、配列に変換
+      UserMailer.daily_digest(user, notifications.to_a).deliver_later
     end
   end
 end


### PR DESCRIPTION
## 問題

16:00と17:00のダイジェストメール配信で以下のエラーが発生し、メールが送信されませんでした：

```
ActiveJob::SerializationError (Unsupported argument type: ActiveRecord::AssociationRelation)
app/jobs/daily_digest_job.rb:50
```

## 原因

`notifications`（ActiveRecord::Relation）を`deliver_later`に直接渡していたため、ActiveJobがシリアライズできずエラーになっていました。

## 修正内容

- `UserMailer.daily_digest(user, notifications).deliver_later`
- → `UserMailer.daily_digest(user, notifications.to_a).deliver_later`

`.to_a`で配列に変換してから渡すように修正しました。

## 確認済み

- エラーログで問題箇所を特定
- 16:00（JST）: sugiweユーザー 5件の通知 → エラー
- 17:00（JST）: nejimakiユーザー 3件の通知 → エラー

## テスト

手動テストが必要です：
```ruby
# コンソールで確認
user = User.find_by(username: 'sugiwe')
notifications = user.notifications.where(action: :new_post).limit(3).to_a
UserMailer.daily_digest(user, notifications).deliver_later
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)