### PR TITLE
digest_timeのタイムゾーン問題を修正

### DIFF
--- a/app/jobs/daily_digest_job.rb
+++ b/app/jobs/daily_digest_job.rb
@@ -7,14 +7,14 @@ class DailyDigestJob < ApplicationJob
     # Time.currentは設定されたタイムゾーン（Tokyo）で時刻を返す
     current_time = Time.current
     current_hour = current_time.hour
+    current_time_str = format("%02d:00", current_hour)
 
-    Rails.logger.info "DailyDigestJob: Running at #{current_hour}:00 (#{Time.zone.name})"
+    Rails.logger.info "DailyDigestJob: Running at #{current_time_str} (#{Time.zone.name})"
 
     # この時刻にダイジェスト配信を希望しているユーザーを取得
-    # 時間範囲での検索により、digest_timeカラムのインデックスを活用
     NotificationSetting
       .email_mode_digest
-      .where(digest_time: current_time.beginning_of_hour..current_time.end_of_hour)
+      .where(digest_time: current_time_str)
       .includes(:user)
       .find_each do |setting|
         send_digest_email(setting.user)

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -22,6 +22,9 @@ class NotificationSetting < ApplicationRecord
 
   # カスタムセッター: "HH:MM:SS"形式を"HH:MM"形式に正規化
   def digest_time=(value)
+    # Timeオブジェクトの場合は "HH:MM" 形式に変換
+    value = value.strftime("%H:%M") if value.respond_to?(:strftime)
+
     if value.is_a?(String) && value.match?(/\A\d{2}:\d{2}(:\d{2})?\z/)
       # "HH:MM:SS" または "HH:MM" 形式を "HH:MM" に統一
       super(value.split(":")[0..1].join(":"))
@@ -38,7 +41,7 @@ class NotificationSetting < ApplicationRecord
 
   def digest_minute
     return 0 if digest_time.blank?
-    digest_time.split(":").last.to_i
+    digest_time.split(":")[1].to_i
   end
 
   # 配信時刻の文字列表現（UI表示用）

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -25,9 +25,11 @@ class NotificationSetting < ApplicationRecord
     # Timeオブジェクトの場合は "HH:MM" 形式に変換
     value = value.strftime("%H:%M") if value.respond_to?(:strftime)
 
-    if value.is_a?(String) && value.match?(/\A\d{2}:\d{2}(:\d{2})?\z/)
-      # "HH:MM:SS" または "HH:MM" 形式を "HH:MM" に統一
-      super(value.split(":")[0..1].join(":"))
+    if value.is_a?(String) && value.match?(/\A\d{1,2}:\d{1,2}(:\d{1,2})?\z/)
+      # "H:MM:SS", "HH:MM:SS", "H:MM", "HH:MM" を "HH:MM" に統一
+      parts = value.split(":")
+      normalized = format("%02d:%02d", parts[0].to_i, parts[1].to_i)
+      super(normalized)
     else
       super(value)
     end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -20,10 +20,11 @@ class NotificationSetting < ApplicationRecord
   # webhook URLが設定されていない場合は、use_discord/use_slackをfalseにする
   before_save :disable_webhooks_if_urls_blank
 
-  # カスタムセッター: "HH:MM:SS"形式の文字列をTime型に変換
+  # カスタムセッター: "HH:MM:SS"形式を"HH:MM"形式に正規化
   def digest_time=(value)
-    if value.is_a?(String) && value.match?(/\A\d{2}:\d{2}:\d{2}\z/)
-      super(Time.zone.parse(value))
+    if value.is_a?(String) && value.match?(/\A\d{2}:\d{2}(:\d{2})?\z/)
+      # "HH:MM:SS" または "HH:MM" 形式を "HH:MM" に統一
+      super(value.split(":")[0..1].join(":"))
     else
       super(value)
     end
@@ -31,16 +32,18 @@ class NotificationSetting < ApplicationRecord
 
   # ダイジェスト配信時刻（時と分を返す）
   def digest_hour
-    digest_time&.hour || 8
+    return 8 if digest_time.blank?
+    digest_time.split(":").first.to_i
   end
 
   def digest_minute
-    digest_time&.min || 0
+    return 0 if digest_time.blank?
+    digest_time.split(":").last.to_i
   end
 
   # 配信時刻の文字列表現（UI表示用）
   def digest_time_display
-    digest_time&.strftime("%H:%M") || "08:00"
+    digest_time.presence || "08:00"
   end
 
   # 即時配信が可能かチェック（副作用なし、CQS原則に準拠）

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -143,7 +143,9 @@ class User < ApplicationRecord
   def create_default_notification_setting
     build_notification_setting(
       notify_member_posts: true,
-      notify_subscription_posts: true
+      notify_subscription_posts: true,
+      email_mode: :digest,
+      digest_time: "08:00"
     ).tap(&:save!)
   end
 

--- a/app/views/settings/notifications/_form.html.slim
+++ b/app/views/settings/notifications/_form.html.slim
@@ -42,8 +42,8 @@
         .ml-9.mt-2.p-3.bg-gray-50.rounded data-email-mode-target="digestSettings" class=(notification_setting.email_mode_digest? ? "" : "hidden")
           = f.label :digest_time, "配信時刻", class: "block text-xs font-medium text-gray-700 mb-1"
           .flex.items-center.gap-2
-            - options = (0..23).map { |h| [sprintf("%02d:00", h), sprintf("%02d:00:00", h)] }
-            - selected = notification_setting.digest_time&.strftime("%H:00:00") || "08:00:00"
+            - options = (0..23).map { |h| [sprintf("%02d:00", h), sprintf("%02d:00", h)] }
+            - selected = notification_setting.digest_time.presence || "08:00"
             = f.select :digest_time, options_for_select(options, selected), {}, { class: "border border-gray-300 rounded px-3 py-2 text-sm bg-white" }
             span.text-xs.text-gray-500 毎日この時刻に配信されます
 

--- a/db/migrate/20260331004210_change_digest_time_to_string.rb
+++ b/db/migrate/20260331004210_change_digest_time_to_string.rb
@@ -5,10 +5,16 @@ class ChangeDigestTimeToString < ActiveRecord::Migration[8.1]
     change_column :notification_settings, :digest_time, :string, default: "08:00", null: false
 
     # 既存データを "08:00" に統一（17:00 JSTは実質08:00 UTCなので、意図した08:00 JSTに修正）
-    NotificationSetting.update_all(digest_time: "08:00")
+    # マイグレーション内でモデルを使わず、SQLで直接更新
+    execute "UPDATE notification_settings SET digest_time = '08:00'"
   end
 
   def down
-    change_column :notification_settings, :digest_time, :time, default: "08:00:00", null: false
+    # string型からtime型への変換にはUSING句が必要
+    # デフォルト値を先に削除してから型変換
+    execute "ALTER TABLE notification_settings ALTER COLUMN digest_time DROP DEFAULT"
+    execute "ALTER TABLE notification_settings ALTER COLUMN digest_time TYPE time USING (digest_time || ':00')::time"
+    execute "ALTER TABLE notification_settings ALTER COLUMN digest_time SET DEFAULT '08:00:00'::time"
+    execute "ALTER TABLE notification_settings ALTER COLUMN digest_time SET NOT NULL"
   end
 end

--- a/db/migrate/20260331004210_change_digest_time_to_string.rb
+++ b/db/migrate/20260331004210_change_digest_time_to_string.rb
@@ -1,0 +1,14 @@
+class ChangeDigestTimeToString < ActiveRecord::Migration[8.1]
+  def up
+    # 既存データを一旦バックアップとして読み取り、文字列型に変換
+    # time型は "HH:MM:SS" 形式で保存
+    change_column :notification_settings, :digest_time, :string, default: "08:00", null: false
+
+    # 既存データを "08:00" に統一（17:00 JSTは実質08:00 UTCなので、意図した08:00 JSTに修正）
+    NotificationSetting.update_all(digest_time: "08:00")
+  end
+
+  def down
+    change_column :notification_settings, :digest_time, :time, default: "08:00:00", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_29_052608) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_31_004210) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -103,7 +103,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_29_052608) do
 
   create_table "notification_settings", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.time "digest_time", default: "2000-01-01 08:00:00", null: false
+    t.string "digest_time", default: "08:00", null: false
     t.string "discord_webhook_url"
     t.date "email_count_reset_at"
     t.integer "email_count_this_month", default: 0, null: false

--- a/spec/factories/notification_settings.rb
+++ b/spec/factories/notification_settings.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
 
     # メール通知のデフォルト値
     email_mode { "digest" }
-    digest_time { Time.zone.parse("08:00:00") }
+    digest_time { "08:00" }
     email_count_this_month { 0 }
     email_count_reset_at { nil }
 
@@ -32,7 +32,7 @@ FactoryBot.define do
 
     trait :email_digest do
       email_mode { "digest" }
-      digest_time { Time.zone.parse("08:00:00") }
+      digest_time { "08:00" }
     end
 
     trait :email_realtime do

--- a/spec/models/notification_setting_spec.rb
+++ b/spec/models/notification_setting_spec.rb
@@ -102,9 +102,10 @@ RSpec.describe NotificationSetting, type: :model do
       expect(setting.email_mode).to eq("digest")
     end
 
-    it "digest_timeは08:00:00がデフォルト" do
-      expect(setting.digest_time.hour).to eq(8)
-      expect(setting.digest_time.min).to eq(0)
+    it "digest_timeは08:00がデフォルト" do
+      expect(setting.digest_time).to eq("08:00")
+      expect(setting.digest_hour).to eq(8)
+      expect(setting.digest_minute).to eq(0)
     end
 
     it "email_count_this_monthは0がデフォルト" do
@@ -141,18 +142,18 @@ RSpec.describe NotificationSetting, type: :model do
     describe "#digest_time=" do
       let(:setting) { create(:notification_setting) }
 
-      it "文字列形式の時刻を正しくパースする" do
+      it "HH:MM:SS形式の文字列をHH:MM形式に正規化する" do
         setting.digest_time = "15:30:00"
-        expect(setting.digest_time.hour).to eq(15)
-        expect(setting.digest_time.min).to eq(30)
+        expect(setting.digest_time).to eq("15:30")
+        expect(setting.digest_hour).to eq(15)
+        expect(setting.digest_minute).to eq(30)
       end
 
-      it "Time型の値をそのまま受け入れる" do
-        time = Time.zone.parse("18:45:00")
-        setting.digest_time = time
-        # time型は時刻のみを保持するため、時・分で比較
-        expect(setting.digest_time.hour).to eq(18)
-        expect(setting.digest_time.min).to eq(45)
+      it "HH:MM形式の文字列をそのまま受け入れる" do
+        setting.digest_time = "18:45"
+        expect(setting.digest_time).to eq("18:45")
+        expect(setting.digest_hour).to eq(18)
+        expect(setting.digest_minute).to eq(45)
       end
 
       it "不正な形式の文字列はそのまま渡す" do

--- a/spec/models/notification_setting_spec.rb
+++ b/spec/models/notification_setting_spec.rb
@@ -156,6 +156,20 @@ RSpec.describe NotificationSetting, type: :model do
         expect(setting.digest_minute).to eq(45)
       end
 
+      it "1桁の時間を2桁に正規化する" do
+        setting.digest_time = "8:05"
+        expect(setting.digest_time).to eq("08:05")
+        expect(setting.digest_hour).to eq(8)
+        expect(setting.digest_minute).to eq(5)
+      end
+
+      it "1桁の時間（秒付き）も正規化する" do
+        setting.digest_time = "9:30:00"
+        expect(setting.digest_time).to eq("09:30")
+        expect(setting.digest_hour).to eq(9)
+        expect(setting.digest_minute).to eq(30)
+      end
+
       it "不正な形式の文字列はそのまま渡す" do
         expect { setting.digest_time = "invalid" }.not_to raise_error
       end

--- a/spec/system/notification_settings_spec.rb
+++ b/spec/system/notification_settings_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe "NotificationSettings", type: :system do
 
       # 設定が保存されたことを確認
       user.notification_setting.reload
-      expect(user.notification_setting.digest_time.hour).to eq(18)
+      expect(user.notification_setting.digest_time).to eq("18:00")
+      expect(user.notification_setting.digest_hour).to eq(18)
     end
   end
 


### PR DESCRIPTION
## 問題

本番環境で新規ユーザーを作成した際、通知設定のデフォルトdigest_time（ダイジェスト配信時刻）が**17:00 JST**と表示される問題が発生していました。

### 原因

PostgreSQLの`time`型とRailsのタイムゾーン処理の組み合わせにより、以下の問題が発生していました：

1. マイグレーションでデフォルト値として`"08:00:00"`を設定
2. PostgreSQLの`time`型はタイムゾーン情報を持たない
3. Railsがこの値を読み書きする際に**UTC時刻として解釈**
4. データベースには`08:00 UTC`として保存される
5. 日本時間（JST = UTC+9）で表示すると`17:00`になる

本番環境での検証結果：
```ruby
# 実際に保存されている値
digest_time: 2000-01-01 17:00:00 +0900
# UTCで見ると
UTC: 2000-01-01 08:00:00 UTC
```

## 修正内容

### 1. カラム型の変更（マイグレーション）

`digest_time`カラムを`time`型から`string`型に変更し、タイムゾーンの問題を根本から解決：

```ruby
change_column :notification_settings, :digest_time, :string, default: "08:00", null: false
```

既存ユーザーのデータも`"08:00"`に統一：
```ruby
NotificationSetting.update_all(digest_time: "08:00")
```

### 2. モデルの更新

#### NotificationSetting モデル
- `digest_time=`: `"HH:MM:SS"`形式を`"HH:MM"`形式に正規化
- `digest_hour`/`digest_minute`: 文字列をパースして数値を返す
- `digest_time_display`: 文字列をそのまま返す（Time型のstrftimeは不要に）

#### User モデル
デフォルト値を明示的に設定：
```ruby
def create_default_notification_setting
  build_notification_setting(
    notify_member_posts: true,
    notify_subscription_posts: true,
    email_mode: :digest,
    digest_time: "08:00"  # 明示的に設定
  )
end
```

### 3. ジョブの更新

`DailyDigestJob`の時刻比較を文字列比較に変更：
```ruby
current_time_str = format("%02d:00", current_hour)
NotificationSetting
  .email_mode_digest
  .where(digest_time: current_time_str)
```

### 4. ビューとテストの更新

- フォームのセレクトボックスを`"HH:MM"`形式に対応
- ファクトリーを文字列形式に更新
- テストを文字列型に対応

## テスト結果

✅ モデルテスト: 51 examples, 0 failures
✅ システムテスト: 10 examples, 0 failures  
✅ 全テスト: 142 examples, 0 failures

## デプロイ後の影響

- 既存ユーザー: マイグレーションにより自動的に`"08:00"`に統一される
- 新規ユーザー: デフォルトで`"08:00"`が設定される
- ダイジェストメール配信: 文字列比較で正しく動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)