### PR TITLE
投稿・交換日記UIの改善

### DIFF
--- a/app/controllers/threads/posts_controller.rb
+++ b/app/controllers/threads/posts_controller.rb
@@ -81,8 +81,8 @@ class Threads::PostsController < Threads::ApplicationController
     end
 
     @post.status = "published"
-    @post.published_at = Time.current
     if @post.valid?
+      @post.published_at = Time.current
       ActiveRecord::Base.transaction do
         @post.save!
         @thread.update_last_post_metadata!
@@ -123,7 +123,7 @@ class Threads::PostsController < Threads::ApplicationController
     # 前回の投稿（最新の公開済み投稿）を取得
     @prev_post = @thread.posts.published
                         .includes(:user, thumbnail_attachment: :blob)
-                        .reorder(Arel.sql("COALESCE(published_at, created_at) DESC"))
+                        .reorder(published_at: :desc)
                         .first
   end
 

--- a/app/controllers/threads/posts_controller.rb
+++ b/app/controllers/threads/posts_controller.rb
@@ -80,14 +80,17 @@ class Threads::PostsController < Threads::ApplicationController
       return
     end
 
-    ActiveRecord::Base.transaction do
-      @post.publish!
-      @thread.update_last_post_metadata!
+    @post.status = "published"
+    if @post.valid?
+      ActiveRecord::Base.transaction do
+        @post.save!
+        @thread.update_last_post_metadata!
+      end
+      redirect_to thread_post_path(@thread.slug, @post), notice: "投稿しました"
+    else
+      set_prev_post
+      render :edit, status: :unprocessable_entity
     end
-
-    redirect_to thread_post_path(@thread.slug, @post), notice: "投稿しました"
-  rescue ActiveRecord::RecordInvalid
-    redirect_to edit_thread_post_path(@thread.slug, @post), alert: "投稿に失敗しました"
   end
 
   private

--- a/app/controllers/threads/posts_controller.rb
+++ b/app/controllers/threads/posts_controller.rb
@@ -123,7 +123,7 @@ class Threads::PostsController < Threads::ApplicationController
     # 前回の投稿（最新の公開済み投稿）を取得
     @prev_post = @thread.posts.published
                         .includes(:user, thumbnail_attachment: :blob)
-                        .reorder(created_at: :desc)
+                        .reorder(Arel.sql("COALESCE(published_at, created_at) DESC"))
                         .first
   end
 

--- a/app/controllers/threads/posts_controller.rb
+++ b/app/controllers/threads/posts_controller.rb
@@ -81,6 +81,7 @@ class Threads::PostsController < Threads::ApplicationController
     end
 
     @post.status = "published"
+    @post.published_at = Time.current
     if @post.valid?
       ActiveRecord::Base.transaction do
         @post.save!

--- a/app/controllers/threads/posts_controller.rb
+++ b/app/controllers/threads/posts_controller.rb
@@ -92,6 +92,9 @@ class Threads::PostsController < Threads::ApplicationController
       set_prev_post
       render :edit, status: :unprocessable_entity
     end
+  rescue ActiveRecord::RecordInvalid
+    set_prev_post
+    render :edit, status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/threads_controller.rb
+++ b/app/controllers/threads_controller.rb
@@ -40,7 +40,7 @@ class ThreadsController < ApplicationController
                 .where(status: "published")
                 .includes(:user, :thread)
                 .where(thread_id: current_user.subscribed_threads.public_threads.select(:id))
-                .reorder(Arel.sql("COALESCE(published_at, created_at) DESC"))
+                .reorder(published_at: :desc)
                 .page(params[:page])
                 .per(20)
   end
@@ -51,7 +51,7 @@ class ThreadsController < ApplicationController
     order_direction = @current_sort == "oldest" ? :asc : :desc
     @posts = @thread.visible_posts_for(current_user)
                     .includes(:user)
-                    .reorder(Arel.sql("COALESCE(published_at, created_at) #{order_direction.to_s.upcase}"))
+                    .reorder(published_at: order_direction)
                     .page(params[:page])
                     .per(10)
     @members = @thread.memberships.includes(:user).order(:position)

--- a/app/controllers/threads_controller.rb
+++ b/app/controllers/threads_controller.rb
@@ -28,6 +28,23 @@ class ThreadsController < ApplicationController
     @threads = fetch_user_threads(paginate: true)
   end
 
+  def subscription_posts
+    # ログイン必須
+    unless logged_in?
+      redirect_to login_path, alert: "ログインが必要です"
+      return
+    end
+
+    # フォロー中交換日記の新着投稿をページネーション付きで取得
+    @posts = Post.unscope(where: :status)
+                .where(status: "published")
+                .includes(:user, :thread)
+                .where(thread_id: current_user.subscribed_threads.public_threads.select(:id))
+                .reorder(Arel.sql("COALESCE(published_at, created_at) DESC"))
+                .page(params[:page])
+                .per(20)
+  end
+
   def show
     # ソート順（デフォルトは新しい順）
     @current_sort = params[:sort] == "oldest" ? "oldest" : "newest"

--- a/app/controllers/threads_controller.rb
+++ b/app/controllers/threads_controller.rb
@@ -36,6 +36,7 @@ class ThreadsController < ApplicationController
     end
 
     # フォロー中交換日記の新着投稿をページネーション付きで取得
+    # unscope: default_scopeは["published", "anonymized"]だが、ここでは"published"のみを取得したいため
     @posts = Post.unscope(where: :status)
                 .where(status: "published")
                 .includes(:user, :thread)

--- a/app/controllers/threads_controller.rb
+++ b/app/controllers/threads_controller.rb
@@ -166,7 +166,7 @@ class ThreadsController < ApplicationController
   def set_sample_threads
     @sample_threads = CorrespondenceThread.sample_threads
                                           .discoverable
-                                          .includes(:users, :memberships)
+                                          .includes(:users, memberships: :user)
                                           .recent_order
                                           .limit(3)
   end
@@ -174,7 +174,7 @@ class ThreadsController < ApplicationController
   def fetch_user_threads(limit: nil, paginate: false)
     threads = CorrespondenceThread.user_threads
                                   .discoverable
-                                  .includes(:users, :memberships)
+                                  .includes(:users, memberships: :user)
                                   .recent_order
 
     if paginate

--- a/app/controllers/threads_controller.rb
+++ b/app/controllers/threads_controller.rb
@@ -34,7 +34,7 @@ class ThreadsController < ApplicationController
     order_direction = @current_sort == "oldest" ? :asc : :desc
     @posts = @thread.visible_posts_for(current_user)
                     .includes(:user)
-                    .reorder(created_at: order_direction)
+                    .reorder(Arel.sql("COALESCE(published_at, created_at) #{order_direction.to_s.upcase}"))
                     .page(params[:page])
                     .per(10)
     @members = @thread.memberships.includes(:user).order(:position)

--- a/app/javascript/controllers/draft_autosave_controller.js
+++ b/app/javascript/controllers/draft_autosave_controller.js
@@ -6,7 +6,8 @@ export default class extends Controller {
   static targets = ["title", "body", "status", "form"]
   static values = {
     url: String,
-    interval: { type: Number, default: 3000 } // 3秒間隔
+    interval: { type: Number, default: 1000 }, // 1秒間隔（debounce）
+    maxInterval: { type: Number, default: 5000 } // 5秒間隔（強制保存）
   }
 
   connect() {
@@ -26,6 +27,12 @@ export default class extends Controller {
     // カウントダウン用インターバル
     this.countdownInterval = null
 
+    // 強制保存用タイマー
+    this.forceSaveTimer = null
+
+    // 最後の保存時刻
+    this.lastSaveTime = Date.now()
+
     // 初期ステータス表示
     this.updateStatus("入力内容は自動保存されます")
   }
@@ -37,6 +44,9 @@ export default class extends Controller {
     }
     if (this.countdownInterval) {
       clearInterval(this.countdownInterval)
+    }
+    if (this.forceSaveTimer) {
+      clearTimeout(this.forceSaveTimer)
     }
   }
 
@@ -84,6 +94,39 @@ export default class extends Controller {
       }
       this.save()
     }, this.intervalValue)
+
+    // 強制保存タイマーを設定（最後の保存から maxInterval 経過で発動）
+    this.scheduleForceSave()
+  }
+
+  // 強制保存タイマーをスケジュール
+  scheduleForceSave() {
+    // 既存の強制保存タイマーをクリア
+    if (this.forceSaveTimer) {
+      clearTimeout(this.forceSaveTimer)
+    }
+
+    // 最後の保存からの経過時間を計算
+    const timeSinceLastSave = Date.now() - this.lastSaveTime
+    const timeUntilForceSave = Math.max(0, this.maxIntervalValue - timeSinceLastSave)
+
+    // 強制保存タイマーを設定
+    this.forceSaveTimer = setTimeout(() => {
+      // debounce タイマーとカウントダウンをクリア
+      if (this.saveTimer) {
+        clearTimeout(this.saveTimer)
+        this.saveTimer = null
+      }
+      if (this.countdownInterval) {
+        clearInterval(this.countdownInterval)
+        this.countdownInterval = null
+      }
+
+      // 変更がある場合のみ保存
+      if (this.hasChanges()) {
+        this.save()
+      }
+    }, timeUntilForceSave)
   }
 
   // 変更があるかチェック
@@ -126,6 +169,7 @@ export default class extends Controller {
         // 保存成功
         this.savedTitle = this.titleTarget.value
         this.savedBody = this.bodyTarget.value
+        this.lastSaveTime = Date.now() // 最後の保存時刻を更新
         this.updateStatus(`保存済み (${this.formatTime(new Date())})`)
       } else {
         // エラー時にレスポンスからエラーメッセージを取得
@@ -155,5 +199,14 @@ export default class extends Controller {
       minute: "2-digit",
       second: "2-digit"
     })
+  }
+
+  // 投稿前に保存を確認（外部から呼び出し可能）
+  async ensureSaved() {
+    // 未保存の変更がある場合は保存
+    if (this.hasChanges()) {
+      await this.save()
+    }
+    return !this.hasChanges() // 保存成功したか確認
   }
 }

--- a/app/javascript/controllers/publish_controller.js
+++ b/app/javascript/controllers/publish_controller.js
@@ -25,36 +25,13 @@ export default class extends Controller {
       }
     }
 
-    // 保存完了後、または自動保存が不要な場合は公開処理を実行
-    // Turboを使ってPOSTリクエストを送信
+    // 保存完了後、Turbo経由で公開処理を実行（フラッシュメッセージを保持）
     const url = link.href
-    const csrfToken = document.querySelector('[name="csrf-token"]')?.content
 
-    try {
-      const response = await fetch(url, {
-        method: "POST",
-        headers: {
-          "X-CSRF-Token": csrfToken,
-          "Accept": "text/vnd.turbo-stream.html, text/html, application/xhtml+xml"
-        },
-        redirect: "follow"
-      })
-
-      if (response.redirected) {
-        // リダイレクト先にページ遷移
-        window.location.href = response.url
-      } else if (response.ok) {
-        // Turbo Streamレスポンスの場合は自動的に処理される
-        const html = await response.text()
-        Turbo.renderStreamMessage(html)
-      } else {
-        // エラーレスポンスの場合
-        const html = await response.text()
-        document.body.innerHTML = html
-      }
-    } catch (error) {
-      console.error("Publish error:", error)
-      alert("投稿に失敗しました。もう一度お試しください。")
-    }
+    // TurboのvisitメソッドでPOSTリクエストを送信
+    // これによりフラッシュメッセージが正しく表示される
+    Turbo.visit(url, {
+      method: "post"
+    })
   }
 }

--- a/app/javascript/controllers/publish_controller.js
+++ b/app/javascript/controllers/publish_controller.js
@@ -1,0 +1,60 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 投稿公開時に自動保存を確認するコントローラー
+export default class extends Controller {
+  static targets = ["link"]
+
+  async publish(event) {
+    event.preventDefault()
+
+    const link = event.currentTarget
+    const autosaveController = this.application.getControllerForElementAndIdentifier(
+      document.querySelector('[data-controller~="draft-autosave"]'),
+      "draft-autosave"
+    )
+
+    // 自動保存コントローラーが存在する場合は保存を確認
+    if (autosaveController) {
+      // 未保存の変更がある場合は保存
+      const saved = await autosaveController.ensureSaved()
+
+      if (!saved) {
+        // 保存失敗の場合は公開を中止
+        alert("下書きの保存に失敗しました。もう一度お試しください。")
+        return
+      }
+    }
+
+    // 保存完了後、または自動保存が不要な場合は公開処理を実行
+    // Turboを使ってPOSTリクエストを送信
+    const url = link.href
+    const csrfToken = document.querySelector('[name="csrf-token"]')?.content
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "X-CSRF-Token": csrfToken,
+          "Accept": "text/vnd.turbo-stream.html, text/html, application/xhtml+xml"
+        },
+        redirect: "follow"
+      })
+
+      if (response.redirected) {
+        // リダイレクト先にページ遷移
+        window.location.href = response.url
+      } else if (response.ok) {
+        // Turbo Streamレスポンスの場合は自動的に処理される
+        const html = await response.text()
+        Turbo.renderStreamMessage(html)
+      } else {
+        // エラーレスポンスの場合
+        const html = await response.text()
+        document.body.innerHTML = html
+      }
+    } catch (error) {
+      console.error("Publish error:", error)
+      alert("投稿に失敗しました。もう一度お試しください。")
+    }
+  }
+}

--- a/app/javascript/controllers/publish_controller.js
+++ b/app/javascript/controllers/publish_controller.js
@@ -25,13 +25,24 @@ export default class extends Controller {
       }
     }
 
-    // 保存完了後、Turbo経由で公開処理を実行（フラッシュメッセージを保持）
+    // 保存完了後、フォームを作成してPOST送信（フラッシュメッセージを保持）
     const url = link.href
+    const csrfToken = document.querySelector('[name="csrf-token"]')?.content
 
-    // TurboのvisitメソッドでPOSTリクエストを送信
-    // これによりフラッシュメッセージが正しく表示される
-    Turbo.visit(url, {
-      method: "post"
-    })
+    // 隠しフォームを作成してPOST送信
+    const form = document.createElement('form')
+    form.method = 'POST'
+    form.action = url
+
+    // CSRFトークンを追加
+    const csrfInput = document.createElement('input')
+    csrfInput.type = 'hidden'
+    csrfInput.name = 'authenticity_token'
+    csrfInput.value = csrfToken
+    form.appendChild(csrfInput)
+
+    // フォームをDOMに追加して送信
+    document.body.appendChild(form)
+    form.submit()
   }
 }

--- a/app/javascript/controllers/publish_controller.js
+++ b/app/javascript/controllers/publish_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
 
     const link = event.currentTarget
     const autosaveController = this.application.getControllerForElementAndIdentifier(
-      document.querySelector('[data-controller~="draft-autosave"]'),
+      this.element,
       "draft-autosave"
     )
 

--- a/app/models/correspondence_thread.rb
+++ b/app/models/correspondence_thread.rb
@@ -190,7 +190,7 @@ class CorrespondenceThread < ApplicationRecord
   # エクスポート用JSON生成（メンバーのみ実行可能）
   def to_export_json(posts_with_includes: nil)
     # postsが渡されていない場合は取得（重複クエリ対策）
-    posts_data = posts_with_includes || published_posts.includes(:user).with_attached_thumbnail.order(created_at: :asc)
+    posts_data = posts_with_includes || published_posts.includes(:user).with_attached_thumbnail.reorder(Arel.sql("COALESCE(published_at, created_at) ASC"))
 
     {
       thread: {
@@ -225,7 +225,7 @@ class CorrespondenceThread < ApplicationRecord
   # 画像付きZIPエクスポート（メンバーのみ実行可能）
   def export_with_images_zip
     # 投稿データを一度だけ取得（重複クエリ対策）
-    posts_with_includes = published_posts.includes(:user).with_attached_thumbnail.order(created_at: :asc).to_a
+    posts_with_includes = published_posts.includes(:user).with_attached_thumbnail.reorder(Arel.sql("COALESCE(published_at, created_at) ASC")).to_a
 
     stringio = Zip::OutputStream.write_buffer do |zip|
       # 1. JSON追加（取得済みのpostsデータを再利用）

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -49,8 +49,8 @@ class Post < ApplicationRecord
   end
 
   # Scopes
-  # published_at 順（nil の場合は created_at をフォールバック）
-  scope :published_posts, -> { where(status: [ "published", "anonymized" ]).order(Arel.sql("COALESCE(published_at, created_at) ASC")) }
+  # published_at 順（バックフィル済みのため published_at を直接使用）
+  scope :published_posts, -> { where(status: [ "published", "anonymized" ]).order(published_at: :asc) }
   scope :draft_posts, -> { where(status: "draft") }
 
   # Default scope: 公開済み投稿と匿名化済み投稿を表示（下書きは除外）
@@ -60,16 +60,16 @@ class Post < ApplicationRecord
   def prev
     thread.posts.unscope(where: :status)
           .where(status: "published")
-          .where("COALESCE(published_at, created_at) < ?", published_at || created_at)
-          .reorder(Arel.sql("COALESCE(published_at, created_at) DESC"))
+          .where("published_at < ?", published_at)
+          .reorder(published_at: :desc)
           .first
   end
 
   def next
     thread.posts.unscope(where: :status)
           .where(status: "published")
-          .where("COALESCE(published_at, created_at) > ?", published_at || created_at)
-          .reorder(Arel.sql("COALESCE(published_at, created_at) ASC"))
+          .where("published_at > ?", published_at)
+          .reorder(published_at: :asc)
           .first
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -49,7 +49,8 @@ class Post < ApplicationRecord
   end
 
   # Scopes
-  scope :published_posts, -> { where(status: [ "published", "anonymized" ]).order(created_at: :asc) }
+  # published_at 順（nil の場合は created_at をフォールバック）
+  scope :published_posts, -> { where(status: [ "published", "anonymized" ]).order(Arel.sql("COALESCE(published_at, created_at) ASC")) }
   scope :draft_posts, -> { where(status: "draft") }
 
   # Default scope: 公開済み投稿と匿名化済み投稿を表示（下書きは除外）
@@ -59,16 +60,16 @@ class Post < ApplicationRecord
   def prev
     thread.posts.unscope(where: :status)
           .where(status: "published")
-          .where("created_at < ?", created_at)
-          .reorder(created_at: :desc)
+          .where("COALESCE(published_at, created_at) < ?", published_at || created_at)
+          .reorder(Arel.sql("COALESCE(published_at, created_at) DESC"))
           .first
   end
 
   def next
     thread.posts.unscope(where: :status)
           .where(status: "published")
-          .where("created_at > ?", created_at)
-          .reorder(created_at: :asc)
+          .where("COALESCE(published_at, created_at) > ?", published_at || created_at)
+          .reorder(Arel.sql("COALESCE(published_at, created_at) ASC"))
           .first
   end
 
@@ -78,9 +79,14 @@ class Post < ApplicationRecord
     self.user_id == user.id
   end
 
+  # 表示用の公開日時（published_at があればそれを、なければ created_at をフォールバック）
+  def display_published_at
+    published_at || created_at
+  end
+
   # 下書きを公開する
   def publish!
-    update!(status: "published")
+    update!(status: "published", published_at: Time.current)
   end
 
   # 公開可能かどうか（自分のターンかつ下書き）

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -210,7 +210,7 @@ class User < ApplicationRecord
         .where(status: "published")
         .includes(:user, :thread)
         .where(thread_id: subscribed_threads.public_threads.select(:id))
-        .reorder(Arel.sql("COALESCE(published_at, created_at) DESC"))
+        .reorder(published_at: :desc)
         .limit(limit)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -210,7 +210,7 @@ class User < ApplicationRecord
         .where(status: "published")
         .includes(:user, :thread)
         .where(thread_id: subscribed_threads.public_threads.select(:id))
-        .reorder(created_at: :desc)
+        .reorder(Arel.sql("COALESCE(published_at, created_at) DESC"))
         .limit(limit)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -205,12 +205,12 @@ class User < ApplicationRecord
   end
 
   # 4. フォロー中交換日記の新着投稿を取得（冗長なクエリを削減）
-  def fetch_recent_posts
+  def fetch_recent_posts(limit: 5)
     Post.unscope(where: :status)
         .where(status: "published")
         .includes(:user, :thread)
         .where(thread_id: subscribed_threads.public_threads.select(:id))
         .reorder(created_at: :desc)
-        .limit(10)
+        .limit(limit)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -206,6 +206,7 @@ class User < ApplicationRecord
 
   # 4. フォロー中交換日記の新着投稿を取得（冗長なクエリを削減）
   def fetch_recent_posts(limit: 5)
+    # unscope: default_scopeは["published", "anonymized"]だが、ここでは"published"のみを取得したいため
     Post.unscope(where: :status)
         .where(status: "published")
         .includes(:user, :thread)

--- a/app/views/posts/_post_card.html.slim
+++ b/app/views/posts/_post_card.html.slim
@@ -15,7 +15,7 @@
           .flex.items-center.gap-2
             .w-5.h-5.rounded-full.bg-gray-300.flex-shrink-0
             span.text-xs.text-gray-400 退会済みユーザー
-            span.text-xs.text-gray-400 = post.created_at.strftime("%Y/%m/%d")
+            span.text-xs.text-gray-400 = post.display_published_at.strftime("%Y/%m/%d")
 - else
   a.block.border.rounded-lg.overflow-hidden.hover:shadow-md.transition-shadow.group class="#{post.draft? ? 'border-amber-200 bg-amber-50/30' : 'border-gray-200'}" href=thread_post_path(post.thread.slug, post)
     .flex.flex-row
@@ -43,5 +43,5 @@
             .w-5.h-5.rounded-full.bg-gray-200.flex-shrink-0.overflow-hidden
               = render "shared/avatar", user: post.user, show_fallback: true
             span.text-xs.text-gray-500 = post.user.display_name
-            span.text-xs.text-gray-400 = post.created_at.strftime("%Y/%m/%d")
+            span.text-xs.text-gray-400 = post.display_published_at.strftime("%Y/%m/%d")
           span.text-xs.text-gray-400.group-hover:text-gray-700.md:ml-auto →

--- a/app/views/threads/_thread.html.slim
+++ b/app/views/threads/_thread.html.slim
@@ -18,6 +18,10 @@
     - if thread.description.present?
       p.text-sm.text-gray-500.line-clamp-2 = thread.description
 
-    / メタ情報（メンバー）
-    .text-xs.text-gray-400.mt-auto
-      = thread.users.map { |u| "@#{u.username}" }.join(" × ")
+    / メタ情報（メンバー - アイコンのみ、参加順）
+    .flex.items-center.gap-1.mt-auto
+      - thread.memberships.order(:position).limit(10).each do |membership|
+        .w-5.h-5.rounded-full.bg-gray-200.flex-shrink-0.overflow-hidden title="@#{membership.user.username}"
+          = render "shared/avatar", user: membership.user, show_fallback: true
+      - if thread.memberships.count > 10
+        span.text-xs.text-gray-400.ml-1 +#{thread.memberships.count - 10}

--- a/app/views/threads/_thread.html.slim
+++ b/app/views/threads/_thread.html.slim
@@ -20,8 +20,9 @@
 
     / メタ情報（メンバー - アイコンのみ、参加順）
     .flex.items-center.gap-1.mt-auto
-      - thread.memberships.order(:position).limit(10).each do |membership|
+      - memberships = thread.memberships.to_a.sort_by(&:position)
+      - memberships.take(10).each do |membership|
         .w-5.h-5.rounded-full.bg-gray-200.flex-shrink-0.overflow-hidden title="@#{membership.user.username}"
           = render "shared/avatar", user: membership.user, show_fallback: true
-      - if thread.memberships.count > 10
-        span.text-xs.text-gray-400.ml-1 +#{thread.memberships.count - 10}
+      - if memberships.size > 10
+        span.text-xs.text-gray-400.ml-1 +#{memberships.size - 10}

--- a/app/views/threads/index.html.slim
+++ b/app/views/threads/index.html.slim
@@ -15,8 +15,10 @@
     / 2. フォロー中交換日記の新着投稿
     - if @recent_posts.present?
       section
-        h2.text-xl.text-gray-900.mb-4
-          | 📬 フォロー中交換日記の新着投稿
+        .flex.items-center.justify-between.mb-4
+          h2.text-xl.text-gray-900
+            | 📬 フォロー中交換日記の新着投稿
+          = link_to "すべて見る", subscription_posts_path, class: "text-sm text-gray-600 hover:text-gray-900 border border-gray-300 rounded px-3 py-1.5"
         .flex.flex-col.gap-4
           = render partial: "posts/post_card", collection: @recent_posts, as: :post
 

--- a/app/views/threads/posts/_form.html.slim
+++ b/app/views/threads/posts/_form.html.slim
@@ -92,4 +92,4 @@
           / 下書きを編集中（draft-first patternにより、@post.persisted? は常に true）
           = f.submit "下書き更新", class: "bg-gray-500 text-white rounded-md px-5 py-2 text-sm font-medium hover:bg-gray-600 cursor-pointer", name: "commit", value: "下書き更新"
           - if @thread.my_turn?(current_user)
-            = link_to "投稿する", publish_thread_post_path(@thread.slug, @post), data: { turbo_method: :post }, class: "bg-blue-600 text-white rounded-md px-5 py-2 text-sm font-medium hover:bg-blue-700 inline-block"
+            = link_to "投稿する", publish_thread_post_path(@thread.slug, @post), data: { action: "click->publish#publish" }, class: "bg-blue-600 text-white rounded-md px-5 py-2 text-sm font-medium hover:bg-blue-700 inline-block"

--- a/app/views/threads/posts/_form.html.slim
+++ b/app/views/threads/posts/_form.html.slim
@@ -2,7 +2,7 @@
   .flex.flex-col.gap-5
 
     .flex.flex-col.gap-1
-      = f.label :title, "タイトル#{@post.published? ? '（必須）' : '（任意）'}", class: "text-sm font-medium text-gray-700"
+      = f.label :title, "タイトル（公開時は必須）", class: "text-sm font-medium text-gray-700"
       = f.text_field :title,
           placeholder: "投稿のタイトルを入力してください",
           autofocus: true,

--- a/app/views/threads/posts/_previous_post.html.slim
+++ b/app/views/threads/posts/_previous_post.html.slim
@@ -8,7 +8,7 @@ details.border.border-gray-200.rounded-lg.bg-gray-50 open=true
         = render "shared/avatar", user: prev_post.user, show_fallback: true
       .flex.flex-col
         = link_to prev_post.user.display_name, user_path(prev_post.user.username), class: "text-sm font-medium text-gray-700 transition-opacity hover:opacity-70"
-        span.text-xs.text-gray-400 = prev_post.created_at.strftime("%Y年%m月%d日")
+        span.text-xs.text-gray-400 = prev_post.display_published_at.strftime("%Y年%m月%d日")
 
     / サムネイル画像（あれば）
     - if prev_post.thumbnail.attached?

--- a/app/views/threads/posts/edit.html.slim
+++ b/app/views/threads/posts/edit.html.slim
@@ -2,7 +2,7 @@
 - content_for :main_width, 'max-w-7xl' if @post.draft?
 
 / 自動保存コントローラーのスコープ（下書きの場合のみ）
-- autosave_data = @post.draft? ? { controller: "draft-autosave", "draft-autosave-url-value": thread_post_path(@thread.slug, @post) } : {}
+- autosave_data = @post.draft? ? { controller: "draft-autosave publish", "draft-autosave-url-value": thread_post_path(@thread.slug, @post) } : {}
 div data=autosave_data
   - if @post.draft?
     / 下書き編集時は new.html.slim と同じレイアウト

--- a/app/views/threads/posts/show.html.slim
+++ b/app/views/threads/posts/show.html.slim
@@ -46,7 +46,7 @@
           = render "shared/avatar", user: @post.user, show_fallback: true
         .flex.flex-col
           = link_to @post.user.display_name, user_path(@post.user.username), class: "text-base font-medium text-gray-700 transition-opacity hover:opacity-70"
-          span.text-sm.text-gray-400 = @post.created_at.strftime("%Y年%m月%d日 %H:%M")
+          span.text-sm.text-gray-400 = @post.display_published_at.strftime("%Y年%m月%d日 %H:%M")
 
     / 本文（手紙の内容）
     .text-base.text-gray-800.leading-loose.markdown-body = render_markdown(@post.body)

--- a/app/views/threads/subscription_posts.html.slim
+++ b/app/views/threads/subscription_posts.html.slim
@@ -1,0 +1,24 @@
+- content_for :title, "フォロー中交換日記の新着投稿 - coconikki"
+
+.max-w-4xl.mx-auto
+  / ヘッダー
+  .mb-6
+    = link_to "← ホームに戻る", root_path, class: "text-sm text-gray-500 hover:text-gray-700"
+
+  .mb-6
+    h1.text-2xl.text-gray-900 📬 フォロー中交換日記の新着投稿
+
+  / 投稿一覧
+  - if @posts.present?
+    .flex.flex-col.gap-4
+      = render partial: "posts/post_card", collection: @posts, as: :post
+
+    / ページネーション
+    .mt-6
+      = paginate @posts
+
+  - else
+    .text-center.py-16.text-gray-400
+      p.text-lg フォロー中の交換日記の投稿がまだありません
+      p.text-sm.mt-2
+        = link_to "交換日記を探す", browse_threads_path, class: "underline text-blue-600"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,9 @@ Rails.application.routes.draw do
   # 全スレッド一覧（ブラウズページ）
   get "/threads", to: "threads#browse", as: :browse_threads
 
+  # フォロー中交換日記の投稿一覧（ログイン必須）
+  get "/subscription_posts", to: "threads#subscription_posts", as: :subscription_posts
+
   # 管理画面（管理者のみ）
   namespace :admin do
     root to: "dashboard#index"

--- a/db/migrate/20260404083525_backfill_published_at_for_posts.rb
+++ b/db/migrate/20260404083525_backfill_published_at_for_posts.rb
@@ -1,0 +1,16 @@
+class BackfillPublishedAtForPosts < ActiveRecord::Migration[8.1]
+  def up
+    # published と anonymized の投稿に対して、published_at が nil の場合は created_at で埋める
+    execute <<-SQL
+      UPDATE posts
+      SET published_at = created_at
+      WHERE status IN ('published', 'anonymized')
+        AND published_at IS NULL
+    SQL
+  end
+
+  def down
+    # ロールバック時は何もしない（published_at をクリアすると情報が失われる）
+    # 必要に応じて手動で対応
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_31_004210) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_04_083525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     # タイムスタンプ
     created_at { Time.current }
     updated_at { Time.current }
+    published_at { Time.current }
 
     # ユーザーをスレッドのメンバーにする
     after(:build) do |post|
@@ -24,6 +25,7 @@ FactoryBot.define do
       status { :draft }
       title { nil }
       body { Faker::Lorem.paragraph }
+      published_at { nil }
     end
 
     # Trait: 匿名化済み


### PR DESCRIPTION
## 概要
投稿と交換日記の表示に関する複数のUI改善をまとめたPRです。

## 変更内容

### 1. 投稿のタイトルバリデーションUIを改善
- タイトルラベルを「タイトル（公開時は必須）」に固定表示
- タイトル空欄での公開時、バリデーションエラーを適切に表示するよう修正（redirect → render）

### 2. 投稿の表示順と日付をpublished_at基準に変更
- 下書き作成時刻（created_at）ではなく、公開時刻（published_at）で投稿をソート
- 既存データのバックフィル用マイグレーション追加
- 自由投稿モードで複数人が投稿した際の順序が正しく表示されるように

### 3. 交換日記カードのメンバー表示をアイコンのみに変更
- テキスト表示（@username × @username...）からアイコン表示に変更
- 参加順に並べ、10人まで表示し、それ以降は「+N」で表示
- 7人以上のスレッドでカードが長くなりすぎる問題を解決

### 4. 下書き自動保存を改善してデータロスを防止
- 自動保存のdebounce間隔を3秒→1秒に短縮
- 最後の保存から5秒経過で強制保存する仕組みを追加
- 投稿前に確実に保存を完了させる `publish_controller.js` を追加
- 高速タイピング→即座に投稿した場合のデータロスを防止

### 5. 投稿時のフラッシュメッセージ表示を修正
- publish_controller.jsでTurbo.visit使用時にフラッシュメッセージが消える問題を修正
- 隠しフォームを作成してPOST送信する方式に変更

### 6. ホームページの新着投稿を5件に絞り、専用一覧ページを追加
- トップページの「フォロー中交換日記の新着投稿」を10件→5件に変更
- 「すべて見る」ボタンを追加（デザインは「新しい交換日記」ボタンと統一）
- 専用一覧ページ（/subscription_posts）を新規作成
  - ページネーション対応（1ページ20件）
  - published_at降順でソート

## テスト計画
- [ ] タイトル空欄での投稿時、適切なエラーメッセージが表示されること
- [ ] 自由投稿モードで複数人が投稿した際、公開順に表示されること
- [ ] 交換日記カードでメンバーアイコンが参加順に表示されること
- [ ] 10人以上のメンバーがいる場合「+N」表示になること
- [ ] 高速タイピング後すぐに投稿しても内容が保存されること
- [ ] 投稿後「投稿しました」フラッシュメッセージが表示されること
- [ ] ホームページで新着投稿が5件のみ表示されること
- [ ] 「すべて見る」から専用ページに遷移でき、ページネーションが機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)