### PR TITLE
投稿公開時にタイトルが空の場合は自動的に日付を設定

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -94,31 +94,27 @@ class Post < ApplicationRecord
 
   # 下書きを公開する
   def publish!
+    # published_atを設定
+    self.published_at = Time.current
+    # タイトルが空の場合は日付を自動設定（RSS対応）
+    if title.blank?
+      self.title = published_at.in_time_zone("Tokyo").strftime("%Y年%-m月%-d日")
+    end
+    self.status = "published"
+
     # カスタムslugが設定されていない場合、または日付のみの場合は公開時に連番を付与
     if slug.blank? || slug.match?(/\A\d{4}-\d{2}-\d{2}\z/)
       # トランザクション内でスレッドをロックして、同時公開による競合を防ぐ
       Post.transaction do
         # スレッドをロックして、同じスレッド内の同時公開をブロック
         thread.lock!
-
-        # published_atを設定してから保存（コールバックで再度slug生成されないようにslugを先に設定）
-        self.published_at = Time.current
+        # コールバックで再度slug生成されないようにslugを先に設定
         self.slug = generate_sequential_slug(self.published_at)
-        # タイトルが空の場合は日付を自動設定（RSS対応）
-        if title.blank?
-          self.title = published_at.in_time_zone("Tokyo").strftime("%Y年%-m月%-d日")
-        end
-        self.status = "published"
         save!
       end
     else
-      # カスタムslugの場合は通常通り更新
-      self.published_at = Time.current
-      # タイトルが空の場合は日付を自動設定（RSS対応）
-      if title.blank?
-        self.title = published_at.in_time_zone("Tokyo").strftime("%Y年%-m月%-d日")
-      end
-      update!(status: "published")
+      # カスタムslugの場合は通常通り保存
+      save!
     end
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -104,12 +104,21 @@ class Post < ApplicationRecord
         # published_atを設定してから保存（コールバックで再度slug生成されないようにslugを先に設定）
         self.published_at = Time.current
         self.slug = generate_sequential_slug(self.published_at)
+        # タイトルが空の場合は日付を自動設定（RSS対応）
+        if title.blank?
+          self.title = published_at.in_time_zone("Tokyo").strftime("%Y年%-m月%-d日")
+        end
         self.status = "published"
         save!
       end
     else
       # カスタムslugの場合は通常通り更新
-      update!(status: "published", published_at: Time.current)
+      self.published_at = Time.current
+      # タイトルが空の場合は日付を自動設定（RSS対応）
+      if title.blank?
+        self.title = published_at.in_time_zone("Tokyo").strftime("%Y年%-m月%-d日")
+      end
+      update!(status: "published")
     end
   end
 


### PR DESCRIPTION
## 概要
投稿を公開する際、タイトルが空の場合は自動的に日付（「YYYY年M月D日」形式）をデータベースに保存するように修正しました。

## 背景
現在の実装では、`display_title` メソッドで表示時に日付を計算していますが、データベースの `title` カラムは空のままです。これにより、RSSフィードなどの外部システムでタイトルが空で表示されてしまう問題がありました。

## 変更内容
- `Post#publish!` メソッドに、タイトルが空の場合は `published_at` の東京時間で「YYYY年M月D日」形式の日付を自動設定する処理を追加
- 通常のslug生成パスとカスタムslugパスの両方に対応

## 修正ファイル
- `app/models/post.rb`

## 期待される動作
1. タイトルを空にして投稿を公開すると、データベースの `title` カラムに「2026年4月11日」のような日付が自動保存される
2. RSSフィードでも正しくタイトルが表示される
3. 既存の `display_title` メソッドもそのまま動作する（タイトルがあればそれを返す）

## テスト計画
- [ ] タイトルを空にして投稿を公開し、データベースの `title` カラムに日付が保存されることを確認
- [ ] RSSフィードでタイトルが正しく表示されることを確認
- [ ] タイトルを入力して投稿した場合、入力したタイトルがそのまま保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)