### PR TITLE
投稿時のサムネイル画像アップロード機能を修正

### DIFF
--- a/app/controllers/threads/posts_controller.rb
+++ b/app/controllers/threads/posts_controller.rb
@@ -45,7 +45,7 @@ class Threads::PostsController < Threads::ApplicationController
   end
 
   def update
-    @post.thumbnail.purge if params[:post][:remove_thumbnail] == "1"
+    @post.thumbnail.purge if params[:post]&.[](:remove_thumbnail) == "1"
 
     respond_to do |format|
       if @post.update(post_params)
@@ -116,7 +116,7 @@ class Threads::PostsController < Threads::ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, :body, :thumbnail)
+    params.fetch(:post, {}).permit(:title, :body, :thumbnail)
   end
 
   def require_post_owner

--- a/app/javascript/controllers/publish_controller.js
+++ b/app/javascript/controllers/publish_controller.js
@@ -8,6 +8,7 @@ export default class extends Controller {
     event.preventDefault()
 
     const link = event.currentTarget
+    const publishUrl = link.href
     const autosaveController = this.application.getControllerForElementAndIdentifier(
       this.element,
       "draft-autosave"
@@ -25,8 +26,91 @@ export default class extends Controller {
       }
     }
 
-    // 保存完了後、フォームを作成してPOST送信（フラッシュメッセージを保持）
-    const url = link.href
+    // サムネイル画像が選択されているかチェック
+    const thumbnailInput = this.element.querySelector('input[type="file"][name="post[thumbnail]"]')
+    const hasThumbnailSelected = thumbnailInput && thumbnailInput.files.length > 0
+
+    if (hasThumbnailSelected) {
+      // 画像が選択されている場合は、先にフォーム全体を送信して画像をアップロード
+      const thumbnailSaved = await this.saveDraftWithThumbnail()
+      if (!thumbnailSaved) {
+        return // エラー時は中断
+      }
+      // 画像保存後、そのまま公開処理に進む
+    }
+
+    // 公開処理を実行
+    this.submitPublish(publishUrl)
+  }
+
+  async saveDraftWithThumbnail() {
+    // 元のフォームを取得
+    const form = this.element.querySelector('form')
+    if (!form) {
+      alert("フォームが見つかりませんでした")
+      return false
+    }
+
+    // サムネイル input を取得
+    const thumbnailInput = this.element.querySelector('input[type="file"][name="post[thumbnail]"]')
+    if (!thumbnailInput || !thumbnailInput.files.length) {
+      // 画像が選択されていない（念のためのチェック）
+      return true
+    }
+
+    // FormData を手動で構築
+    const formData = new FormData()
+
+    // タイトルと本文を追加
+    const titleInput = form.querySelector('input[name="post[title]"]')
+    const bodyInput = form.querySelector('textarea[name="post[body]"]')
+
+    if (titleInput) {
+      formData.append('post[title]', titleInput.value)
+    }
+    if (bodyInput) {
+      formData.append('post[body]', bodyInput.value)
+    }
+
+    // サムネイル画像を追加
+    formData.append('post[thumbnail]', thumbnailInput.files[0])
+
+    // デバッグ: FormData の中身を確認
+    console.log("FormData contents:")
+    for (let [key, value] of formData.entries()) {
+      console.log(key, value)
+    }
+
+    // 下書き保存のためのリクエストを送信
+    try {
+      const response = await fetch(form.action, {
+        method: 'PATCH',
+        body: formData,
+        headers: {
+          'X-CSRF-Token': document.querySelector('[name="csrf-token"]')?.content,
+          'Accept': 'application/json'
+          // Content-Type は fetch が自動的に multipart/form-data に設定してくれる
+        }
+      })
+
+      if (response.ok) {
+        // 保存成功
+        console.log("Thumbnail saved successfully")
+        return true
+      } else {
+        const errorText = await response.text()
+        console.error("Save error response:", errorText)
+        alert("画像のアップロードに失敗しました。もう一度お試しください。")
+        return false
+      }
+    } catch (error) {
+      console.error("Draft save error:", error)
+      alert("画像のアップロードに失敗しました。もう一度お試しください。")
+      return false
+    }
+  }
+
+  submitPublish(url) {
     const csrfToken = document.querySelector('[name="csrf-token"]')?.content
 
     // 隠しフォームを作成してPOST送信

--- a/app/javascript/controllers/publish_controller.js
+++ b/app/javascript/controllers/publish_controller.js
@@ -59,6 +59,8 @@ export default class extends Controller {
     }
 
     // FormData を手動で構築
+    // form_with が生成するフォームでは new FormData(form) が正しく動作しないため、
+    // 各フィールドを明示的に追加する必要があります
     const formData = new FormData()
 
     // タイトルと本文を追加
@@ -75,12 +77,6 @@ export default class extends Controller {
     // サムネイル画像を追加
     formData.append('post[thumbnail]', thumbnailInput.files[0])
 
-    // デバッグ: FormData の中身を確認
-    console.log("FormData contents:")
-    for (let [key, value] of formData.entries()) {
-      console.log(key, value)
-    }
-
     // 下書き保存のためのリクエストを送信
     try {
       const response = await fetch(form.action, {
@@ -95,16 +91,12 @@ export default class extends Controller {
 
       if (response.ok) {
         // 保存成功
-        console.log("Thumbnail saved successfully")
         return true
       } else {
-        const errorText = await response.text()
-        console.error("Save error response:", errorText)
         alert("画像のアップロードに失敗しました。もう一度お試しください。")
         return false
       }
     } catch (error) {
-      console.error("Draft save error:", error)
       alert("画像のアップロードに失敗しました。もう一度お試しください。")
       return false
     }


### PR DESCRIPTION
## 問題

新規投稿時にサムネイル画像を選択して「投稿する」ボタンを押しても、画像がアップロードされずに公開されてしまう不具合がありました。

## 原因

1. 自動保存機能がタイトルと本文のみを送信し、画像を含んでいなかった
2. 公開処理の前に画像をアップロードする仕組みがなかった
3. コントローラー側でパラメータが存在しない場合のエラーハンドリングが不足していた

## 修正内容

### app/javascript/controllers/publish_controller.js

- 投稿公開前にサムネイル画像の選択をチェックする処理を追加
- 画像が選択されている場合は、`saveDraftWithThumbnail()`で先に画像をアップロード
- FormDataを手動で構築し、`post[title]`、`post[body]`、`post[thumbnail]`を明示的に追加
- アップロード成功後に公開処理を実行

### app/controllers/threads/posts_controller.rb

- `post_params`メソッドで`require`→`fetch`に変更し、パラメータが存在しない場合でもエラーにならないように修正
- サムネイル削除チェックで安全なナビゲーション演算子(`&.`)を使用

## テスト結果

- ✅ 新規投稿時にサムネイル画像を選択して公開 → 画像が正しくアップロードされることを確認
- ✅ 既存投稿の編集時にサムネイル画像を追加 → 正常に動作することを確認

## 変更ファイル

- `app/javascript/controllers/publish_controller.js`
- `app/controllers/threads/posts_controller.rb`