### PR TITLE
招待ページにnoindexメタタグを追加してSEO対策を実装

### DIFF
--- a/app/controllers/threads/invitations_controller.rb
+++ b/app/controllers/threads/invitations_controller.rb
@@ -24,6 +24,8 @@ class Threads::InvitationsController < Threads::ApplicationController
   # GET /invite/:token
   # 招待を受け取った人が承認画面を見る
   def show
+    # 招待トークンが検索エンジンに露出しないようnoindex設定
+    @noindex = true
     # 招待トークンをセッションに保存（ログイン許可に使用）
     session[:invitation_token] = @invitation.token
     # 未ログイン時も招待画面を表示（show.html.slimで分岐）

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -4,8 +4,8 @@ html
     title
       = content_for(:title) || "coconikki"
     meta name="viewport" content="width=device-width,initial-scale=1"
-    / noindexメタタグ（スレッド詳細・投稿詳細ページでnoindexが有効な場合）
-    - if @thread&.noindex?
+    / noindexメタタグ（スレッド詳細・投稿詳細ページでnoindexが有効な場合、または招待ページなど）
+    - if @thread&.noindex? || @noindex
       meta name="robots" content="noindex"
     = csrf_meta_tags
     = csp_meta_tag

--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -1,0 +1,46 @@
+FactoryBot.define do
+  factory :invitation do
+    # 関連
+    association :thread, factory: :correspondence_thread
+    association :invited_by, factory: :user
+
+    # 基本属性
+    invitation_type { "single_use" }
+    expiry_type { "seven_days" }
+    use_count { 0 }
+
+    # タイムスタンプ（コールバックで自動設定されるがテスト用に明示）
+    created_at { Time.current }
+    updated_at { Time.current }
+    accepted_at { nil }
+    last_used_at { nil }
+
+    # token と expires_at は before_validation コールバックで自動生成
+
+    # Trait: 無制限招待
+    trait :unlimited do
+      invitation_type { "unlimited" }
+      expiry_type { "unlimited" }
+    end
+
+    # Trait: 期限なし
+    trait :no_expiry do
+      expiry_type { "unlimited" }
+    end
+
+    # Trait: 使用済み
+    trait :used do
+      use_count { 1 }
+      accepted_at { 1.hour.ago }
+      last_used_at { 1.hour.ago }
+    end
+
+    # Trait: 期限切れ
+    trait :expired do
+      expiry_type { "seven_days" }
+      after(:create) do |invitation|
+        invitation.update_column(:expires_at, 1.day.ago)
+      end
+    end
+  end
+end

--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -9,13 +9,8 @@ FactoryBot.define do
     expiry_type { "seven_days" }
     use_count { 0 }
 
-    # タイムスタンプ（コールバックで自動設定されるがテスト用に明示）
-    created_at { Time.current }
-    updated_at { Time.current }
-    accepted_at { nil }
-    last_used_at { nil }
-
     # token と expires_at は before_validation コールバックで自動生成
+    # created_at, updated_at は ActiveRecord が自動設定
 
     # Trait: 無制限招待
     trait :unlimited do

--- a/spec/system/invitations_spec.rb
+++ b/spec/system/invitations_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe "Invitations", type: :system do
+  describe "招待ページのSEO設定" do
+    let(:user) { create(:user) }
+    let(:correspondence_thread) { create(:correspondence_thread, :free) }
+    let(:invitation) { create(:invitation, thread: correspondence_thread, invited_by: user) }
+
+    it "招待ページにnoindexメタタグが設定されている" do
+      visit invitation_path(invitation.token)
+
+      expect(page).to have_css('meta[name="robots"][content="noindex"]', visible: false)
+    end
+
+    it "招待ページのタイトルが正しく表示される" do
+      visit invitation_path(invitation.token)
+
+      expect(page).to have_title("招待 - #{correspondence_thread.title} - coconikki")
+    end
+  end
+
+  describe "招待ページの表示" do
+    let(:user) { create(:user) }
+    let(:correspondence_thread) { create(:correspondence_thread, :free, title: "テスト交換日記") }
+    let(:invitation) { create(:invitation, thread: correspondence_thread, invited_by: user) }
+
+    context "未ログインユーザーの場合" do
+      it "ログインボタンが表示される" do
+        visit invitation_path(invitation.token)
+
+        expect(page).to have_content("交換日記への招待")
+        expect(page).to have_content("@#{user.username}")
+        expect(page).to have_content("テスト交換日記")
+        expect(page).to have_content("参加するにはログインが必要です")
+        expect(page).to have_link("ログインして参加する", href: login_path)
+      end
+    end
+
+    context "ログイン済みユーザーの場合" do
+      let(:logged_in_user) { create(:user) }
+
+      before do
+        login_as(logged_in_user)
+      end
+
+      it "参加ボタンが表示される" do
+        visit invitation_path(invitation.token)
+
+        expect(page).to have_content("交換日記への招待")
+        expect(page).to have_content("@#{user.username}")
+        expect(page).to have_content("テスト交換日記")
+        expect(page).to have_button("参加する")
+        expect(page).to have_link("断る", href: root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

招待URL (`/invite/:token`) が検索エンジンにインデックスされると、招待トークンが露出し意図しない第三者が参加できてしまう問題に対処しました。

## 背景

- 招待ページは未ログインユーザーもアクセス可能なため、検索エンジンのクローラーもアクセス可能
- 検索結果に招待URLが表示されると、セキュリティとプライバシーの両面で問題がある

## 変更内容

### 実装

- **[app/controllers/threads/invitations_controller.rb](app/controllers/threads/invitations_controller.rb#L27-L28)**: `show` アクションで `@noindex = true` を設定
- **[app/views/layouts/application.html.slim](app/views/layouts/application.html.slim#L7-L9)**: noindex条件に `|| @noindex` を追加し、コメントも更新

### テスト

- **[spec/factories/invitations.rb](spec/factories/invitations.rb)**: Invitationモデルのfactoryを新規作成
  - 基本的な招待データ
  - `:unlimited`, `:no_expiry`, `:used`, `:expired` のtrait
- **[spec/system/invitations_spec.rb](spec/system/invitations_spec.rb)**: システムスペックを新規作成
  - ✅ noindexメタタグが正しく設定されることを検証
  - ✅ ページタイトルの検証
  - ✅ 未ログイン時とログイン時の表示の違いを検証

## テスト結果

```
bundle exec rspec spec/system/invitations_spec.rb

....

Finished in 0.78 seconds
4 examples, 0 failures
```

## 影響範囲

- 招待ページ (`/invite/:token`) のみ
- 既存の `@thread.noindex?` の仕組みと統一された実装
- 検索エンジンへの影響: 招待ページがインデックスから除外される（意図した動作）

## スクリーンショット

実装後、招待ページのHTMLヘッダーに以下が追加されます:

```html
<meta name="robots" content="noindex">
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)